### PR TITLE
Publish Code Coverage Exec Files and Enable publishing testable jars 

### DIFF
--- a/os-ballerina/build.gradle
+++ b/os-ballerina/build.gradle
@@ -35,13 +35,12 @@ dependencies {
 }
 
 clean {
-    delete "$project.projectDir/target"
+    delete "${project.projectDir}/target"
 }
 
 jar {
     manifest {
-        attributes('Implementation-Title': project.name,
-                'Implementation-Version': project.version)
+        attributes('Implementation-Title': project.name, 'Implementation-Version': project.version)
     }
 }
 
@@ -80,23 +79,23 @@ task copyStdlibs(type: Copy) {
 }
 
 task copyToLib(type: Copy) {
-    into "$project.projectDir/lib"
+    into "${project.projectDir}/lib"
     from configurations.externalJars
 }
 
 def packageName = "os"
 def packageOrg = "ballerina"
-def ballerinaConfigFile = new File("$project.projectDir/Ballerina.toml")
-def ballerinaDependencyFile = new File("$project.projectDir/Dependencies.toml")
-def artifactBallerinaDocs = file("$project.projectDir/build/docs_parent/")
-def artifactCacheParent = file("$project.projectDir/build/cache_parent/")
-def artifactLibParent = file("$project.projectDir/build/lib_parent/")
-def artifactCodeCoverageReport = file("$project.projectDir/target/cache/tests_cache/coverage/ballerina.exec")
+def ballerinaConfigFile = new File("${project.projectDir}/Ballerina.toml")
+def ballerinaDependencyFile = new File("${project.projectDir}/Dependencies.toml")
+def artifactBallerinaDocs = file("${project.projectDir}/build/docs_parent/")
+def artifactCacheParent = file("${project.projectDir}/build/cache_parent/")
+def artifactLibParent = file("${project.projectDir}/build/lib_parent/")
+def artifactCodeCoverageReport = file("${project.projectDir}/target/cache/tests_cache/coverage/ballerina.exec")
 def tomlVersion = project.version.split("-")[0]
 def ballerinaCentralAccessToken = System.getenv('BALLERINA_CENTRAL_ACCESS_TOKEN')
 def originalConfig = ballerinaConfigFile.text
 def originalDependencies = ballerinaDependencyFile.text
-def distributionBinPath =  project.projectDir.absolutePath + "/build/target/extracted-distributions/jballerina-tools-zip/jballerina-tools-${ballerinaLangVersion}/bin"
+def distributionBinPath = project.projectDir.absolutePath + "/build/target/extracted-distributions/jballerina-tools-zip/jballerina-tools-${ballerinaLangVersion}/bin"
 
 task updateTomlVerions {
     doLast {
@@ -152,9 +151,9 @@ task ballerinaTest {
             workingDir project.projectDir
             environment "JAVA_OPTS", "-DBALLERINA_DEV_COMPILE_BALLERINA_ORG=true"
             if (Os.isFamily(Os.FAMILY_WINDOWS)) {
-                commandLine 'cmd', '/c', "$balJavaDebugParam $distributionBinPath/bal.bat test --code-coverage --includes=* ${groupParams} ${disableGroups} ${debugParams}"
+                commandLine 'cmd', '/c', "${balJavaDebugParam} ${distributionBinPath}/bal.bat test --code-coverage --includes=* ${groupParams} ${disableGroups} ${debugParams} && exit %%ERRORLEVEL%%"
             } else {
-                commandLine 'sh', '-c', "$balJavaDebugParam $distributionBinPath/bal test --code-coverage --includes=* ${groupParams} ${disableGroups} ${debugParams}"
+                commandLine 'sh', '-c', "${balJavaDebugParam} ${distributionBinPath}/bal test --code-coverage --includes=* ${groupParams} ${disableGroups} ${debugParams}"
             }
         }
     }
@@ -187,21 +186,21 @@ task ballerinaBuild {
             workingDir project.projectDir
             environment "JAVA_OPTS", "-DBALLERINA_DEV_COMPILE_BALLERINA_ORG=true"
             if (Os.isFamily(Os.FAMILY_WINDOWS)) {
-                commandLine 'cmd', '/c', "$balJavaDebugParam $distributionBinPath/bal.bat build " +
-                        "$testParams ${debugParams}"
+                commandLine 'cmd', '/c', "${balJavaDebugParam} ${distributionBinPath}/bal.bat build " +
+                        "${testParams} ${debugParams} && exit %%ERRORLEVEL%%"
             } else {
-                commandLine 'sh', '-c', "$balJavaDebugParam $distributionBinPath/bal build $testParams ${debugParams}"
+                commandLine 'sh', '-c', "${balJavaDebugParam} ${distributionBinPath}/bal build ${testParams} ${debugParams}"
             }
         }
         copy {
-            from file("$project.projectDir/target/bala")
-            into file("$artifactCacheParent/bala/${packageOrg}/${packageName}/${tomlVersion}")
+            from file("${project.projectDir}/target/bala")
+            into file("${artifactCacheParent}/bala/${packageOrg}/${packageName}/${tomlVersion}")
         }
         copy {
-            from file("$project.projectDir/target/cache")
+            from file("${project.projectDir}/target/cache")
             exclude '**/*-testable.jar'
             exclude '**/tests_cache/'
-            into file("$artifactCacheParent/cache/")
+            into file("${artifactCacheParent}/cache/")
         }
 
         // Publish to central
@@ -211,9 +210,9 @@ task ballerinaBuild {
                 workingDir project.projectDir
                 environment "JAVA_OPTS", "-DBALLERINA_DEV_COMPILE_BALLERINA_ORG=true"
                 if (Os.isFamily(Os.FAMILY_WINDOWS)) {
-                    commandLine 'cmd', '/c', "$distributionBinPath/bal.bat push && exit %%ERRORLEVEL%%"
+                    commandLine 'cmd', '/c', "${distributionBinPath}/bal.bat push && exit %%ERRORLEVEL%%"
                 } else {
-                    commandLine 'sh', '-c', "$distributionBinPath/bal push"
+                    commandLine 'sh', '-c', "${distributionBinPath}/bal push"
                 }
             }
 
@@ -223,14 +222,14 @@ task ballerinaBuild {
             workingDir project.projectDir
             environment "JAVA_OPTS", "-DBALLERINA_DEV_COMPILE_BALLERINA_ORG=true"
             if (Os.isFamily(Os.FAMILY_WINDOWS)) {
-                commandLine 'cmd', '/c', "$distributionBinPath/bal.bat doc && exit %%ERRORLEVEL%%"
+                commandLine 'cmd', '/c', "${distributionBinPath}/bal.bat doc && exit %%ERRORLEVEL%%"
             } else {
-                commandLine 'sh', '-c', "$distributionBinPath/bal doc"
+                commandLine 'sh', '-c', "${distributionBinPath}/bal doc"
             }
         }
         copy {
-            from file("$project.projectDir/target/apidocs/${packageName}")
-            into file("$project.projectDir/build/docs_parent/docs/${packageName}")
+            from file("${project.projectDir}/target/apidocs/${packageName}")
+            into file("${project.projectDir}/build/docs_parent/docs/${packageName}")
         }
     }
 
@@ -240,7 +239,7 @@ task ballerinaBuild {
 }
 
 task createArtifactZip(type: Zip) {
-    destinationDirectory = file("$buildDir/distributions")
+    destinationDirectory = file("${buildDir}/distributions")
     from ballerinaBuild
 }
 

--- a/os-ballerina/build.gradle
+++ b/os-ballerina/build.gradle
@@ -85,13 +85,14 @@ task copyToLib(type: Copy) {
 
 def packageName = "os"
 def packageOrg = "ballerina"
+def tomlVersion = project.version.split("-")[0]
 def ballerinaConfigFile = new File("${project.projectDir}/Ballerina.toml")
 def ballerinaDependencyFile = new File("${project.projectDir}/Dependencies.toml")
 def artifactBallerinaDocs = file("${project.projectDir}/build/docs_parent/")
 def artifactCacheParent = file("${project.projectDir}/build/cache_parent/")
 def artifactLibParent = file("${project.projectDir}/build/lib_parent/")
 def artifactCodeCoverageReport = file("${project.projectDir}/target/cache/tests_cache/coverage/ballerina.exec")
-def tomlVersion = project.version.split("-")[0]
+def artifactTestableJar = file("$project.projectDir/target/cache/${packageOrg}/${packageName}/${tomlVersion}/java11/")
 def ballerinaCentralAccessToken = System.getenv('BALLERINA_CENTRAL_ACCESS_TOKEN')
 def originalConfig = ballerinaConfigFile.text
 def originalDependencies = ballerinaDependencyFile.text
@@ -158,10 +159,10 @@ task ballerinaBuild {
 
     def testParams = "--skip-tests"
     gradle.taskGraph.whenReady { graph ->
-        if (graph.hasTask(':os-ballerina:build') || graph.hasTask(':os-ballerina:publish'))  {
+        if (graph.hasTask(":${packageName}-ballerina:build") || graph.hasTask(":${packageName}-ballerina:publish")) {
             ballerinaTest.enabled = false
         }
-        if (graph.hasTask(':os-ballerina:test')) {
+        if (graph.hasTask(":${packageName}-ballerina:test")) {
             testParams = "--code-coverage --includes=*"
         }
     }
@@ -230,11 +231,20 @@ task createArtifactZip(type: Zip) {
     from ballerinaBuild
 }
 
+task createTestableJarZip(type: Zip) {
+    archiveName("${packageOrg}-${packageName}-${project.version}-testable-jars.zip")
+    destinationDir(file("${buildDir}/distributions"))
+    from ("${artifactTestableJar}") {
+        include '**/*-testable.jar'
+    }
+}
+
 publishing {
     publications {
         maven(MavenPublication) {
             artifact source: createArtifactZip, extension: 'zip'
             artifact source: artifactCodeCoverageReport, classifier: 'jacoco'
+            artifact source: createTestableJarZip, classifier: 'testable-jars', extension: 'zip'
         }
     }
 
@@ -270,3 +280,5 @@ ballerinaBuild.dependsOn initializeVariables
 ballerinaBuild.dependsOn updateTomlVerions
 ballerinaBuild.finalizedBy revertTomlFile
 build.dependsOn ballerinaBuild
+
+createTestableJarZip.dependsOn ballerinaBuild

--- a/os-ballerina/build.gradle
+++ b/os-ballerina/build.gradle
@@ -139,12 +139,6 @@ task initializeVariables {
 }
 
 task ballerinaTest {
-    dependsOn(copyStdlibs)
-    dependsOn(":os-native:build")
-    dependsOn(":os-test-utils:build")
-    dependsOn(updateTomlVerions)
-    dependsOn(initializeVariables)
-    finalizedBy(revertTomlFile)
 
     doLast {
         exec {
@@ -159,15 +153,8 @@ task ballerinaTest {
     }
 }
 
-test {
-    dependsOn(ballerinaTest)
-}
-
 task ballerinaBuild {
     inputs.dir file(project.projectDir)
-    dependsOn(test)
-    dependsOn(initializeVariables)
-    finalizedBy(revertTomlFile)
 
     def testParams = "--skip-tests"
     gradle.taskGraph.whenReady { graph ->
@@ -263,11 +250,23 @@ publishing {
     }
 }
 
-ballerinaBuild.dependsOn ":os-native:build"
-ballerinaBuild.dependsOn ":os-test-utils:build"
 unpackJballerinaTools.dependsOn copyToLib
 unpackStdLibs.dependsOn unpackJballerinaTools
 copyStdlibs.dependsOn unpackStdLibs
 updateTomlVerions.dependsOn copyStdlibs
+
+ballerinaTest.dependsOn copyStdlibs
+ballerinaTest.dependsOn ":os-native:build"
+ballerinaTest.dependsOn ":os-test-utils:build"
+ballerinaTest.dependsOn updateTomlVerions
+ballerinaTest.dependsOn initializeVariables
+ballerinaTest.finalizedBy revertTomlFile
+test.dependsOn ballerinaTest
+
+ballerinaBuild.dependsOn ":os-native:build"
+ballerinaBuild.dependsOn ":os-test-utils:build"
+ballerinaBuild.dependsOn test
+ballerinaBuild.dependsOn initializeVariables
 ballerinaBuild.dependsOn updateTomlVerions
+ballerinaBuild.finalizedBy revertTomlFile
 build.dependsOn ballerinaBuild


### PR DESCRIPTION
## Purpose
> Publish exec file generate by the testerina as a Maven artifact and enable to publish testable jar files. With this PR exec file will be named as os-ballerina-< version >-jacoco.exec and testable jars will be named as os-ballerina-< version >-testable-jars