### PR TITLE
Upgrade Gradle to 9.5.1 and Ballerina Gradle plugin to 4.0.0

### DIFF
--- a/ballerina/build.gradle
+++ b/ballerina/build.gradle
@@ -15,6 +15,13 @@
  *
  */
 import org.apache.tools.ant.taskdefs.condition.Os
+import org.gradle.process.ExecOperations
+
+import javax.inject.Inject
+
+abstract class BallerinaExecHelper {
+    @Inject abstract ExecOperations getExecOperations()
+}
 
 buildscript {
     repositories {
@@ -104,9 +111,10 @@ def setExecPath(configTOMLFile, distributionBinPath) {
 }
 
 task commitTomlFiles {
+    def execHelper = project.objects.newInstance(BallerinaExecHelper)
     doLast {
         configTOMLFile.text = originalConfigTOMLFile
-        project.exec {
+        execHelper.execOperations.exec {
             ignoreExitValue true
             if (Os.isFamily(Os.FAMILY_WINDOWS)) {
                 commandLine 'cmd', '/c', "git commit -m \"[Automated] Update the native jar versions\" Ballerina.toml Dependencies.toml"

--- a/build-config/checkstyle/build.gradle
+++ b/build-config/checkstyle/build.gradle
@@ -28,7 +28,7 @@ task downloadCheckstyleRuleFiles(type: Download) {
     ])
     overwrite false
     onlyIfNewer true
-    dest buildDir
+    dest layout.buildDirectory.get().asFile
 }
 
 jar {
@@ -39,10 +39,10 @@ clean {
     enabled = false
 }
 
-artifacts.add('default', file("$project.buildDir/checkstyle.xml")) {
+artifacts.add('default', layout.buildDirectory.file("checkstyle.xml")) {
     builtBy('downloadCheckstyleRuleFiles')
 }
 
-artifacts.add('default', file("$project.buildDir/suppressions.xml")) {
+artifacts.add('default', layout.buildDirectory.file("suppressions.xml")) {
     builtBy('downloadCheckstyleRuleFiles')
 }

--- a/build-config/checkstyle/build.gradle
+++ b/build-config/checkstyle/build.gradle
@@ -46,3 +46,5 @@ artifacts.add('default', layout.buildDirectory.file("checkstyle.xml")) {
 artifacts.add('default', layout.buildDirectory.file("suppressions.xml")) {
     builtBy('downloadCheckstyleRuleFiles')
 }
+
+test.mustRunAfter(downloadCheckstyleRuleFiles)

--- a/build.gradle
+++ b/build.gradle
@@ -97,6 +97,14 @@ release {
     }
 }
 
-tasks.named('build') {
-    dependsOn('os-ballerina:build')
+if (tasks.names.contains('build')) {
+    tasks.named('build') {
+        dependsOn('os-ballerina:build')
+
+    }
+} else {
+    tasks.register('build') {
+        dependsOn('os-ballerina:build')
+
+    }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -97,6 +97,6 @@ release {
     }
 }
 
-task build {
+tasks.named('build') {
     dependsOn('os-ballerina:build')
 }

--- a/compiler-plugin-tests/build.gradle
+++ b/compiler-plugin-tests/build.gradle
@@ -27,7 +27,7 @@ description = 'Ballerina - OS Compiler Plugin Tests'
 
 jacoco {
     toolVersion = "${jacocoVersion}"
-    reportsDirectory = file("$project.buildDir/reports/jacoco")
+    reportsDirectory = layout.buildDirectory.dir("reports/jacoco")
 }
 
 jacocoTestReport {
@@ -58,7 +58,6 @@ tasks.withType(JavaCompile) {
     options.encoding = 'UTF-8'
 }
 
-sourceCompatibility = JavaVersion.VERSION_21
 
 test {
     systemProperty "ballerina.offline.flag", "true"
@@ -95,7 +94,7 @@ spotbugsTest {
     ignoreFailures = true
     effort = SpotBugsEffort.MAX
     reportLevel = SpotBugsConfidence.LOW
-    reportsDir = file("$project.buildDir/reports/spotbugs")
+    reportsDir = layout.buildDirectory.dir("reports/spotbugs")
     def excludeFile = file("${rootDir}/build-config/spotbugs-exclude.xml")
     if (excludeFile.exists()) {
         it.excludeFilter = excludeFile

--- a/compiler-plugin/build.gradle
+++ b/compiler-plugin/build.gradle
@@ -54,7 +54,7 @@ spotbugsMain {
     def SpotBugsEffort = classLoader.findLoadedClass("com.github.spotbugs.snom.Effort")
     effort = SpotBugsEffort.MAX
     reportLevel = SpotBugsConfidence.LOW
-    reportsDir = file("$project.buildDir/reports/spotbugs")
+    reportsDir = layout.buildDirectory.dir("reports/spotbugs")
     reports {
         html.enabled true
         text.enabled = true

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,13 +2,13 @@ org.gradle.caching=true
 group=io.ballerina.stdlib
 version=1.10.2-SNAPSHOT
 
-ballerinaGradlePluginVersion=2.3.0
-spotbugsPluginVersion=6.0.18
+ballerinaGradlePluginVersion=4.0.0
+spotbugsPluginVersion=6.5.1
 shadowJarPluginVersion=7.1.2
 downloadPluginVersion=5.4.0
-releasePluginVersion=2.8.0
+releasePluginVersion=3.1.0
 checkstylePluginVersion=10.12.0
-jacocoVersion=0.8.10
+jacocoVersion=0.8.14
 testngVersion=7.7.1
 gsonVersion=2.7
 jacksonDatabindVersion=2.17.2

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,7 +1,8 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.11.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.5.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
+distributionSha256Sum=bafc141b619ad6350fd975fc903156dd5c151998cc8b058e8c1044ab5f7b031f

--- a/native/build.gradle
+++ b/native/build.gradle
@@ -36,7 +36,7 @@ spotbugsMain {
     ignoreFailures = true
     effort = SpotBugsEffort.MAX
     reportLevel = SpotBugsConfidence.LOW
-    reportsDir = file("$project.buildDir/reports/spotbugs")
+    reportsDir = layout.buildDirectory.dir("reports/spotbugs")
     def excludeFile = file("${rootDir}/build-config/spotbugs-exclude.xml")
     if (excludeFile.exists()) {
         it.excludeFilter = excludeFile

--- a/settings.gradle
+++ b/settings.gradle
@@ -29,7 +29,7 @@ pluginManagement {
 }
 
 plugins {
-    id "com.gradle.enterprise" version "3.13.2"
+    id "com.gradle.develocity" version "3.19.2"
 }
 
 rootProject.name = 'os'
@@ -48,9 +48,9 @@ project(':os-ballerina').projectDir = file('ballerina')
 project(':os-compiler-plugin').projectDir = file('compiler-plugin')
 project(':os-compiler-plugin-tests').projectDir = file('compiler-plugin-tests')
 
-gradleEnterprise {
+develocity {
     buildScan {
-        termsOfServiceUrl = 'https://gradle.com/terms-of-service'
-        termsOfServiceAgree = 'yes'
+        termsOfUseUrl = 'https://gradle.com/help/legal-terms-of-use'
+        termsOfUseAgree = 'yes'
     }
 }

--- a/test-utils/build.gradle
+++ b/test-utils/build.gradle
@@ -36,7 +36,7 @@ spotbugsMain {
     ignoreFailures = true
     effort = SpotBugsEffort.MAX
     reportLevel = SpotBugsConfidence.LOW
-    reportsDir = file("$project.buildDir/reports/spotbugs")
+    reportsDir = layout.buildDirectory.dir("reports/spotbugs")
     def excludeFile = file("${rootDir}/build-config/spotbugs-exclude.xml")
     if (excludeFile.exists()) {
         it.excludeFilter = excludeFile


### PR DESCRIPTION
## Summary
- Upgrade the Gradle wrapper to 9.5.1 (with distribution checksum) and the Ballerina Gradle plugin to 4.0.0, needed for Java 21/25 compatibility.
- Fix Gradle 9 breakage: `project.exec` calls now use an injected `ExecOperations`, `com.gradle.enterprise` is migrated to `com.gradle.develocity`, any `task build {}` redefinition is replaced with `tasks.named('build')`, and checkstyle's `build.gradle` drops the deprecated `buildDir` property.

## Test plan
- [x] `./gradlew clean build` passes locally on Gradle 9.5.1 with plugin 4.0.0


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
- Upgrade the Gradle wrapper to 9.5.1 with checksum verification.
- Upgrade the Ballerina, SpotBugs, release, and JaCoCo plugins.
- Update build scripts for Gradle 9 APIs, including `ExecOperations`, `layout.buildDirectory`, safe `build` task configuration, task ordering, and Develocity.
- Improve `testExecNegative` handling for Java 21 and Java 25 process error formats.
- Verify the changes with `./gradlew clean build`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->